### PR TITLE
Fix missing dropdown helper

### DIFF
--- a/MyLFG.lua
+++ b/MyLFG.lua
@@ -1,5 +1,16 @@
 MyLFG = {}
 
+--[[
+  TurtleWoW does not always include the standard UIDropDownMenu
+  helper function.  Add a small fallback to avoid a nil error when
+  the dropdowns are initialised.
+]]
+if UIDropDownMenu_CreateInfo == nil then
+  function UIDropDownMenu_CreateInfo()
+    return {}
+  end
+end
+
 function MyLFG_OnLoad()
   MyLFG.prefix = "-->"
   MyLFG.suffix = "<--"


### PR DESCRIPTION
## Summary
- implement a fallback `UIDropDownMenu_CreateInfo` when not defined

## Testing
- `luac -p MyLFG.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685feaab5c0083298500abbc21d4a416