### PR TITLE
Refactor UI init to occur after login

### DIFF
--- a/MyLFG.lua
+++ b/MyLFG.lua
@@ -11,7 +11,13 @@ if UIDropDownMenu_CreateInfo == nil then
   end
 end
 
-function MyLFG_OnLoad()
+function MyLFG_OnLoad(self)
+  -- defer full UI setup until the player has loaded
+  self:RegisterEvent("PLAYER_LOGIN")
+  self:SetScript("OnEvent", MyLFG_OnEvent)
+end
+
+function MyLFG_InitUI()
   MyLFG.prefix = "-->"
   MyLFG.suffix = "<--"
   MyLFG.interval = 5
@@ -31,7 +37,7 @@ function MyLFG_OnLoad()
       insets = { left = 11, right = 12, top = 12, bottom = 11 }
     })
     MyLFGFrame:SetBackdropColor(0, 0, 0, 0.75)
-    MyLFGFrame:SetBackdropBorderColor(1, 1, 1, 1)
+  MyLFGFrame:SetBackdropBorderColor(1, 1, 1, 1)
   end
 
   MyLFGMessageBox:SetText("DM:W")
@@ -115,6 +121,13 @@ function MyLFG_OnLoad()
       MyLFG.dynamicFrames = {}
     end
   end)
+end
+
+function MyLFG_OnEvent(self, event, ...)
+  if event == "PLAYER_LOGIN" then
+    self:UnregisterEvent("PLAYER_LOGIN")
+    MyLFG_InitUI()
+  end
 end
 
 function MyLFG_UpdateButton()

--- a/MyLFG.xml
+++ b/MyLFG.xml
@@ -86,7 +86,7 @@
       </Button>
     </Frames>
     <Scripts>
-      <OnLoad>MyLFG_OnLoad()</OnLoad>
+      <OnLoad>MyLFG_OnLoad(self)</OnLoad>
     </Scripts>
   </Frame>
 </Ui>


### PR DESCRIPTION
## Summary
- register PLAYER_LOGIN on load and do not set up the UI immediately
- move existing startup logic to new `MyLFG_InitUI`
- call `MyLFG_InitUI` when the login event fires
- update XML to pass `self` to `MyLFG_OnLoad`

## Testing
- `luac -p MyLFG.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686003a5f5d0832999d4bf06ccb07cf3