### PR TITLE
Fix MyLFG load order and onload call

### DIFF
--- a/MyLFG.lua
+++ b/MyLFG.lua
@@ -2,6 +2,7 @@ local PREFIX_OPTIONS = {"LFM", "LF1M", "LFG"}
 local SUFFIX_OPTIONS = {"pst", "/w me", "need all"}
 
 function MyLFG_OnLoad(self)
+    print("MyLFG Loaded")
     -- Initialize checkboxes to checked
     self.Tank:SetChecked(true)
     self.Healer:SetChecked(true)

--- a/MyLFG.toc
+++ b/MyLFG.toc
@@ -3,5 +3,5 @@
 ## Author: Codex
 ## Version: 1.0
 ## Notes: Simple LFG broadcasting tool.
-MyLFG.xml
 MyLFG.lua
+MyLFG.xml


### PR DESCRIPTION
## Summary
- load MyLFG.lua before the XML so the frame's OnLoad handler exists
- confirm the handler runs by printing a message

## Testing
- `luac -p MyLFG.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861a23c86848329b205041903a5ddf5